### PR TITLE
Fixed buffer overflow

### DIFF
--- a/18-channel-CSV-voltage.py
+++ b/18-channel-CSV-voltage.py
@@ -568,7 +568,7 @@ def process_data():
 # Timer for regular updates
 timer = QtCore.QTimer()
 timer.timeout.connect(process_data)
-timer.start(50)
+timer.start(15)# needs to be a bit less than teensy_sample_delay/(num_pins_sampled+1)  (currently 100/5=20) to keep up. 
 
 # Start the main window
 main_window.show()


### PR DESCRIPTION
I changed the timer length on line 571 on the 18-CSV-reader. It needs to be a bit less than teensy_sample_delay/(num_pins_sampled+1)  (currently 100/5=20) to keep up. 

This makes the data I passed into the ADC pins match the output on the graph


Note: if the code needs to run at 10kHz or use a specific samplerate, the Teensy code and data protocol would need to be changed. Lmk if you'd like me to add that.

Also this is what i changed in the teensy code to substitute in a counter
![image](https://github.com/user-attachments/assets/e5c291f7-38b2-4808-bdce-a7d525709bca)
